### PR TITLE
Fix out-of-bounds write to stack array on Linux

### DIFF
--- a/CRC_and_Internet_Checksum/main.c
+++ b/CRC_and_Internet_Checksum/main.c
@@ -106,9 +106,11 @@ void Tx(MODE mode) {
 		if (!fileEnd) break;
 
 		lineLength = strlen(M);
+#ifdef _WIN32
 		M[lineLength - 1] = '\0';	// remove \n
 		M[lineLength - 2] = '\0';	// remove \r
 		lineLength -= 2;
+#endif
 
 		// calculate CRC value
 		if (mode == CRC1) { crcValue = calcCRC1(M, lineLength); crcLength = 1; }


### PR DESCRIPTION
This bug was automatically found by executing the program with [Safe Sulong](https://github.com/graalvm/sulong/blob/master/docs/SAFE-SULONG.md).